### PR TITLE
Refactor: remove hardcoded site url for metadata

### DIFF
--- a/apps/website/.env.example
+++ b/apps/website/.env.example
@@ -1,6 +1,3 @@
-# Website URL
-NEXT_PUBLIC_SITE_URL=
-
 # Event Cache URL
 NEXT_PUBLIC_API_EVENT_CACHE=
 

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -2,30 +2,23 @@ import "@/styles/app.css"
 import "@/styles/globals.css"
 
 import { ReactNode } from "react"
-import { env } from "@/env.mjs"
+import { type Metadata } from "next"
 
 import { siteConfig } from "@/config/site"
 import { fontSans } from "@/lib/fonts"
 import { cn } from "@/lib/utils"
 import RootProvider from "@/components/providers/root-provider"
 
-const url = env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
-
-export const metadata = {
-  metadataBase: new URL(url),
+export const metadata: Metadata = {
   title: `${siteConfig.name} - ${siteConfig.description}`,
   description: siteConfig.description,
   manifest: "/manifest.json",
   icons: {
     icon: "/favicon.ico",
   },
-  visualViewport: {
-    themeColor: "#feefc4",
-  },
   openGraph: {
     title: siteConfig.name,
     description: siteConfig.description,
-    url: url?.toString(),
     siteName: siteConfig.name,
     type: "website",
   },

--- a/apps/website/env.mjs
+++ b/apps/website/env.mjs
@@ -3,7 +3,6 @@ import { z } from "zod"
 
 export const env = createEnv({
   client: {
-    NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
     NEXT_PUBLIC_API_EVENT_CACHE: z.string().url(),
     NEXT_PUBLIC_MAINNET_RPC: z.string().url().optional(),
     NEXT_PUBLIC_BASE_RPC: z.string().url().optional(),
@@ -15,7 +14,6 @@ export const env = createEnv({
     NEXT_PUBLIC_ALCHEMY_API_KEY: z.string().min(1),
   },
   runtimeEnv: {
-    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_API_EVENT_CACHE: process.env.NEXT_PUBLIC_API_EVENT_CACHE,
     NEXT_PUBLIC_MAINNET_RPC: process.env.NEXT_PUBLIC_MAINNET_RPC,
     NEXT_PUBLIC_BASE_RPC: process.env.NEXT_PUBLIC_BASE_RPC,

--- a/apps/website/lib/utils/index.ts
+++ b/apps/website/lib/utils/index.ts
@@ -1,4 +1,3 @@
-import { env } from "@/env.mjs"
 import { ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -13,10 +12,6 @@ export function formatDate(input: string | number): string {
     day: "numeric",
     year: "numeric",
   })
-}
-
-export function absoluteUrl(path: string) {
-  return `${env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"}${path}`
 }
 
 export function trimFormattedBalance(


### PR DESCRIPTION
Removes the `NEXT_PUBLIC_SITE_URL` env variable ad the base url for metadata, now the metadata always uses the underlying deployed url.